### PR TITLE
Bug fix for Cordova Android 11 update

### DIFF
--- a/src/android/barcodescanner.gradle
+++ b/src/android/barcodescanner.gradle
@@ -6,7 +6,7 @@ repositories{
 }
 
 dependencies {
-    compile(name:'barcodescanner-release-2.1.5', ext:'aar')
+    implementation(name:'barcodescanner-release-2.1.5', ext:'aar')
 }
 
 android {


### PR DESCRIPTION
The `compile `keyword within barcodescanner.gradle was throwing an error and preventing a build, replaced with `implementation` keyword

